### PR TITLE
Update README for scripts

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,3 +1,14 @@
+# Read First!
+
+#### [For Mac Users] Install the following
+Make sure you have brew installed on your mac first! Go to [http://brew.sh](http://brew.sh/) and follow the instructions there to install brew on your mac.
+
+- Install **sox** by running ``brew install sox`` on your terminal
+
+- Install **ffmpeg** by running ``brew install ffmpeg``on your terminal
+
+Without these 2, **you will not be able to run** some of the scripts in this repository. In particular, ``multinorm.sh``
+
 # Scripts we use
 
 ## 1. `multinorm.sh` - audio normalization of video files


### PR DESCRIPTION
Added additional instructions to remind users to install 2 dependencies sox and ffmpeg on their mac machines before running multinorm.sh and other possibly dependent scripts.